### PR TITLE
Force inlining of karatsuba

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,6 +5,7 @@ import Poly
 import System.Random
 import System.TimeIt
 import Control.Monad
+import GHC.Exts (inline)
 import PolyFast
 
 main :: IO ()
@@ -38,7 +39,7 @@ main = do
       putStrLn "Karatsuba:"
       _ <- timeIt $ evaluate (karatsubaMult f g)
       putStrLn "Fast Karatsuba:"
-      _ <- timeIt $ evaluate (karatsuba 0 (+) (-) (*) (unwrapPoly f) (unwrapPoly g))
+      _ <- timeIt $ evaluate (inline $ karatsuba 0 (+) (-) (*) (unwrapPoly f) (unwrapPoly g))
       putStrLn "Finished"
       putStrLn ""
 
@@ -60,6 +61,6 @@ main = do
       f :: Poly Int <- randomPoly n
       g :: Poly Int <- randomPoly n
       putStrLn "Fast Karatsuba:"
-      _ <- timeIt $ evaluate (karatsuba 0 (+) (-) (*) (unwrapPoly f) (unwrapPoly g))
+      _ <- timeIt $ evaluate (inline $ karatsuba 0 (+) (-) (*) (unwrapPoly f) (unwrapPoly g))
       putStrLn "Finished"
       putStrLn ""


### PR DESCRIPTION
On my machine this makes relevant benchmarks 10x faster (from 6s to 0.6s for size 65536). If the routine is not inlined, all arithmetic operations remain abstract and cause each and every Int to be boxed and unboxed all over again.